### PR TITLE
Return result of union, not in-going set

### DIFF
--- a/core/src/main/java/org/javarosa/core/model/instance/utils/TreeUtilities.java
+++ b/core/src/main/java/org/javarosa/core/model/instance/utils/TreeUtilities.java
@@ -214,8 +214,7 @@ public class TreeUtilities {
         if (allSelectedChildren == null) {
             return predicateMatches;
         }
-        DataUtil.union(allSelectedChildren, predicateMatches);
-        return allSelectedChildren;
+        return DataUtil.union(allSelectedChildren, predicateMatches);
     }
 
 


### PR DESCRIPTION
Follow-up to https://github.com/dimagi/commcare-android/pull/1307 where I changed the behavior to not modify the vector arguments.

http://manage.dimagi.com/default.asp?231366