### PR TITLE
Better hashcode for FormIndex

### DIFF
--- a/core/src/main/java/org/javarosa/core/model/FormIndex.java
+++ b/core/src/main/java/org/javarosa/core/model/FormIndex.java
@@ -208,11 +208,13 @@ public class FormIndex {
 
     @Override
     public int hashCode() {
-        return (beginningOfForm ? 0 : 31)
-                ^ (endOfForm ? 0 : 31)
-                ^ localIndex
-                ^ instanceIndex
-                ^ (nextLevel == null ? 0 : nextLevel.hashCode());
+        int result = 15;
+        result = 31 * result + (beginningOfForm ? 0 : 1);
+        result = 31 * result + (endOfForm ? 0 : 1);
+        result = 31 * result + localIndex;
+        result = 31 * result + instanceIndex;
+        result = 31 * result + (nextLevel == null ? 0 : nextLevel.hashCode());
+        return result;
     }
 
     @Override


### PR DESCRIPTION
Fix for http://manage.dimagi.com/default.asp?231236 because if two form index instances have similar hashcodes it messes up select-one butotn restores due to https://github.com/dimagi/commcare-android/blob/master/app/src/org/commcare/views/widgets/SelectOneWidget.java#L50